### PR TITLE
Outside Events Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ def('mirroring', Mirroring)
 
 [See demo on Codepen](https://codepen.io/kt3k/pen/mwgWXN?editors=1010)
 
-## debug plugin
+## Debug plugin
 
 `debug plugin` outputs information useful for debugging capsid app.
 
@@ -682,6 +682,47 @@ Via CDN:
 And you'll get additional debug information in console.
 
 <img src="http://capsidjs.github.io/capsid/asset/ss-debug.png" />
+
+## Outside Events Plugin
+
+### Install
+
+Via npm:
+
+```js
+const capsid = require('capsid')
+require('capsid/outside-events')(capsid)
+```
+
+Via cdn:
+
+```html
+<script src="https://unpkg.com/capsid"></script>
+<script src="https://unpkg.com/capsid/dist/capsid-outside-events.js"></script>
+```
+
+With `outside-events-plugin`, you can bind methods to events *outside* of your coponent's element. (This event need to bubble up to `document`)
+
+```js
+@component('modal')
+class Modal {
+  @on.outside('click')
+  close () {
+    this.el.classList.remove('is-shown')
+  }
+
+  open () {
+    this.el.classList.add('is-shown')
+  }
+}
+```
+
+The above `modal` component gets `is-shown` class removed from the element when the outside of modal is clicked.
+
+#### prior art
+
+- [jQuery outside events](https://github.com/cowboy/jquery-outside-events)
+- [react-onclickoutside](https://github.com/Pomax/react-onclickoutside)
 
 # History
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ const paths = {
   src: {
     index: 'src/index.js',
     jqueryPlugin: 'src/plugins/jquery-plugin.js',
+    outsideEventsPlugin: 'src/plugins/outside-events-plugin.js',
     debugPlugin: 'src/plugins/debug-plugin.js'
   },
   dist: 'dist'
@@ -80,4 +81,18 @@ gulp.task('debug-plugin', () => build({
   modes: ['production']
 }))
 
-gulp.task('dist', ['browser', 'cjs', 'jquery-plugin', 'debug-plugin'])
+gulp.task('outside-events-plugin', () => build({
+  input: paths.src.outsideEventsPlugin,
+  format: 'iife',
+  output: 'capsid-outside-events.js',
+  minify: true,
+  modes: ['production', 'development']
+}))
+
+gulp.task('dist', [
+  'browser',
+  'cjs',
+  'jquery-plugin',
+  'debug-plugin',
+  'outside-events-plugin'
+])

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "rollup-plugin-replace": "^2.0.0",
     "rollup-stream": "^1.18.0",
     "standard": "^10.0.3",
+    "testdouble": "^3.2.6",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"

--- a/src/__tests__/helper.js
+++ b/src/__tests__/helper.js
@@ -5,6 +5,7 @@ import { Foo, Bar } from './fixture.js'
 
 global.$ = $
 global.__DEV__ = true
+global.capsidDebugMessage = () => {}
 
 cj(capsid, $)
 

--- a/src/plugins/__tests__/debug-plugin.js
+++ b/src/plugins/__tests__/debug-plugin.js
@@ -1,0 +1,62 @@
+import capsidDebugMessage from '../debug-plugin'
+import td from 'testdouble'
+
+describe('debug-plugin', () => {
+  afterEach(() => {
+    td.reset()
+  })
+
+  describe('with event type message', () => {
+    it('logs event and component names', () => {
+      const e = { type: 'click' }
+      const coelem = { constructor: { name: 'foo' } }
+
+      td.replace(console, 'groupCollapsed')
+      td.replace(console, 'log')
+      td.replace(console, 'groupEnd')
+
+      capsidDebugMessage({ type: 'event', e, coelem })
+
+      td.verify(console.groupCollapsed(
+        '%cclick %con %cfoo',
+        'color: #f012be; font-weight: bold;',
+        '',
+        'color: #2ecc40; font-weight: bold;'
+      ))
+      td.verify(console.log(e))
+      td.verify(console.groupEnd())
+    })
+  })
+
+  describe('with outside event type message', () => {
+    it('logs event and component names', () => {
+      const e = { type: 'click' }
+      const coelem = { constructor: { name: 'foo' } }
+
+      td.replace(console, 'groupCollapsed')
+      td.replace(console, 'log')
+      td.replace(console, 'groupEnd')
+
+      capsidDebugMessage({ type: 'outside-event', e, coelem })
+
+      td.verify(console.groupCollapsed(
+        '%coutside click %con %cfoo',
+        'color: #39cccc; font-weight: bold;',
+        '',
+        'color: #2ecc40; font-weight: bold;'
+      ))
+      td.verify(console.log(e))
+      td.verify(console.groupEnd())
+    })
+  })
+
+  describe('with unknown typee message', () => {
+    it('logs error message', () => {
+      td.replace(console, 'log')
+
+      capsidDebugMessage({ type: 'unknown' })
+
+      td.verify(console.log(`Unknown message: ${JSON.stringify({ type: 'unknown' })}`))
+    })
+  })
+})

--- a/src/plugins/__tests__/outside-events-plugin.js
+++ b/src/plugins/__tests__/outside-events-plugin.js
@@ -1,0 +1,25 @@
+import { callDecorator } from '../../__tests__/helper.js'
+import outsideEventsPlugin from '../outside-events-plugin.js'
+import { on, mount, pluginHooks } from '../../index.js'
+
+outsideEventsPlugin({ on, pluginHooks })
+
+describe('outside-events-plugin', () => {
+  describe('on.outside', () => {
+    it('add outside event handler', done => {
+      class Component {
+        handleOutsideClick () {
+          done()
+        }
+      }
+
+      callDecorator(on.outside('click'), Component, 'handleOutsideClick')
+
+      const div = document.createElement('div')
+
+      mount(Component, div)
+
+      document.body.click()
+    })
+  })
+})

--- a/src/plugins/debug-plugin.js
+++ b/src/plugins/debug-plugin.js
@@ -7,20 +7,52 @@ export default (message: Object) => {
     case 'event':
       onEventMessage(message)
       break
+    case 'outside-event':
+      onOutsideEventMessage(message)
+      break
     default:
       console.log(`Unknown message: ${JSON.stringify(message)}`)
   }
 }
 
-const onEventMessage = ({ el, coelem, e }: { el: HTMLElement, coelem: any, e: Event }) => {
+/**
+ * Gets the bold colored style.
+ * @return {string}
+ */
+const boldColor = color => `color: ${color}; font-weight: bold;`
+
+/**
+ * Gets the displayable component name.
+ */
+const getComponentName = coelem => {
   const { constructor } = coelem
-  const event = `${e.type}`
-  const component = `${constructor[COMPONENT_NAME_KEY] || constructor.name}`
+  return `${constructor[COMPONENT_NAME_KEY] || constructor.name}`
+}
 
-  const eventStyle = 'color: magenta; font-weight: bold;'
-  const componentStyle = 'color: green; font-weight: bold;'
+const onEventMessage = ({ el, coelem, e }: { el: HTMLElement, coelem: any, e: Event }) => {
+  const event = e.type
+  const component = getComponentName(coelem)
 
-  console.groupCollapsed(`%c${event} %con %c${component}`, eventStyle, '', componentStyle)
+  console.groupCollapsed(
+    `%c${event} %con %c${component}`,
+    boldColor('#f012be'),
+    '',
+    boldColor('#2ecc40')
+  )
+  console.log(e)
+  console.groupEnd()
+}
+
+const onOutsideEventMessage = ({ el, coelem, e }: { el: HTMLElement, coelem: any, e: Event }) => {
+  const event = e.type
+  const component = getComponentName(coelem)
+
+  console.groupCollapsed(
+    `%coutside ${event} %con %c${component}`,
+    boldColor('#39cccc'),
+    '',
+    boldColor('#2ecc40')
+  )
   console.log(e)
   console.groupEnd()
 }

--- a/src/plugins/debug-plugin.js
+++ b/src/plugins/debug-plugin.js
@@ -17,19 +17,18 @@ export default (message: Object) => {
 
 /**
  * Gets the bold colored style.
- * @return {string}
  */
-const boldColor = color => `color: ${color}; font-weight: bold;`
+const boldColor = (color: string): string => `color: ${color}; font-weight: bold;`
 
 /**
  * Gets the displayable component name.
  */
-const getComponentName = coelem => {
+const getComponentName = (coelem: any): string => {
   const { constructor } = coelem
   return `${constructor[COMPONENT_NAME_KEY] || constructor.name}`
 }
 
-const onEventMessage = ({ el, coelem, e }: { el: HTMLElement, coelem: any, e: Event }) => {
+const onEventMessage = ({ coelem, e }: { coelem: any, e: Event }) => {
   const event = e.type
   const component = getComponentName(coelem)
 
@@ -43,7 +42,7 @@ const onEventMessage = ({ el, coelem, e }: { el: HTMLElement, coelem: any, e: Ev
   console.groupEnd()
 }
 
-const onOutsideEventMessage = ({ el, coelem, e }: { el: HTMLElement, coelem: any, e: Event }) => {
+const onOutsideEventMessage = ({ coelem, e }: { coelem: any, e: Event }) => {
   const event = e.type
   const component = getComponentName(coelem)
 

--- a/src/plugins/jquery-plugin.js
+++ b/src/plugins/jquery-plugin.js
@@ -72,7 +72,9 @@ if (typeof module !== 'undefined' && module.exports) {
   // If the env is common js, then exports init.
   module.exports = init
 } else if (typeof self !== 'undefined' && self.capsid && self.$) {
-  // If the env is browser and cc and $ is already defined and this plugin isn't applied yet
-  // Then applies the plugin here.
+  // If the env is browser and capsid and $ is already defined
+  // Then applies the plugin
   init(self.capsid, self.$)
+} else {
+  throw new Error('capsid or jquery not defined')
 }

--- a/src/plugins/outside-events-plugin.js
+++ b/src/plugins/outside-events-plugin.js
@@ -1,0 +1,48 @@
+// @flow
+import debugMessage from '../util/debug-message.js'
+
+declare var __DEV__: boolean
+
+const KEY_OUTSIDE_EVENT_LISTENERS = '#O'
+
+const init = (capsid: any): void => {
+  const { on, pluginHooks } = capsid
+
+  on.outside = (event: string) => (target: Object, key: string) => {
+    const Constructor = target.constructor
+
+    Constructor[KEY_OUTSIDE_EVENT_LISTENERS] = (Constructor[KEY_OUTSIDE_EVENT_LISTENERS] || []).concat((el: HTMLElement, coelem: any) => {
+      const listener = (e: Event): void => {
+        if (el !== e.target && !el.contains((e.target: any))) {
+          if (__DEV__) {
+            debugMessage({
+              type: 'outside-event',
+              el,
+              e,
+              coelem
+            })
+          }
+
+          coelem[key](e)
+        }
+      }
+
+      document.addEventListener(event, listener)
+    })
+  }
+
+  pluginHooks.push((el: HTMLElement, coelem: any) => {
+    (coelem.constructor[KEY_OUTSIDE_EVENT_LISTENERS] || []).map(eventListenerBinder => {
+      eventListenerBinder(el, coelem)
+    })
+  })
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  // If the env is common js, then exports init.
+  module.exports = init
+} else if (typeof self !== 'undefined' && self.capsid && self.$) {
+  // If the env is browser and capsid is already defined
+  // Then applies the plugin
+  init(self.capsid)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,7 +1783,7 @@ es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
     es5-ext "^0.10.14"
     es6-symbol "^3.1"
 
-es6-map@^0.1.3:
+es6-map@^0.1.3, es6-map@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
   dependencies:
@@ -3004,6 +3004,10 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
+is-plain-obj@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
 is-plain-object@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -3027,6 +3031,10 @@ is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
 
 is-relative@^0.2.1:
   version "0.2.1"
@@ -3494,7 +3502,7 @@ lodash@^3.10.1, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4300,6 +4308,12 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+quibble@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/quibble/-/quibble-0.5.1.tgz#b7fd1fc0a9c1eea012ac9d71bcb6da8d9a5dc9e9"
+  dependencies:
+    lodash "^4.17.2"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -4550,7 +4564,7 @@ resolve@1.1.7, resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7:
+resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
@@ -4921,6 +4935,13 @@ stringifier@^1.3.0:
     traverse "^0.6.6"
     type-name "^2.0.1"
 
+stringify-object-es5@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz#057c3c9a90a127339bb9d1704a290bb7bd0a1ec5"
+  dependencies:
+    is-plain-obj "^1.0.0"
+    is-regexp "^1.0.0"
+
 stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
@@ -5048,6 +5069,16 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+testdouble@^3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/testdouble/-/testdouble-3.2.6.tgz#8fc47149c59f1becc795bf80f02b41de30ea4035"
+  dependencies:
+    es6-map "^0.1.5"
+    lodash "^4.17.4"
+    quibble "^0.5.1"
+    resolve "^1.3.3"
+    stringify-object-es5 "^2.5.0"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
### Install

Via npm:

```js
const capsid = require('capsid')
require('capsid/outside-events')(capsid)
```

Via cdn:

```html
<script src="https://unpkg.com/capsid"></script>
<script src="https://unpkg.com/capsid/dist/capsid-outside-events.js"></script>
```

With `outside-events-plugin`, you can bind methods to events *outside* of your coponent's element. (This event need to bubble up to `document`)

```js
@component('modal')
class Modal {
  @on.outside('click')
  close () {
    this.el.classList.remove('is-shown')
  }

  open () {
    this.el.classList.add('is-shown')
  }
}
```

The above `modal` component gets `is-shown` class removed from the element when the outside of modal is clicked.

#### prior art

- [jQuery outside events](https://github.com/cowboy/jquery-outside-events)
- [react-onclickoutside](https://github.com/Pomax/react-onclickoutside)

