### PR TITLE
chore: polyfill deno only when testing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "deno.enable": true,
   "deno.lint": true,
   "deno.unstable": true,
-  "deno.config": "deno.json",
+  "deno.config": "./deno.json",
   "deno.suggest.imports.hosts": {
     "https://deno.land": true
   }

--- a/dnt.ts
+++ b/dnt.ts
@@ -7,14 +7,12 @@ await build({
   entryPoints: ["./src/mod.ts"],
   outDir,
   shims: {
-    // see JS docs for overview and more options
-    deno: true,
+    deno: "dev",
   },
   cjs: false,
   typeCheck: false,
   test: false,
   package: {
-    // package.json properties
     name: "capsid",
     version: "1.8.0",
     description:


### PR DESCRIPTION
because Deno namespace is used only while testing