### PR TITLE
docs(readme): update incorrect ts import

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 This example illustrates the basic ideas of `capsid`.
 
 ```ts
-import { on, wired, component } import "capsid";
+import { on, wired, component } from "capsid";
 
 // Declares `mirroring` component.
 // HTML elements which have `mirroring` class will be mounted by this component.


### PR DESCRIPTION
It was formatted as `import { ... } import "module"`, which has been switched to `import { ... } from "module"`